### PR TITLE
create a css file for production build

### DIFF
--- a/components/Html/Html.js
+++ b/components/Html/Html.js
@@ -18,11 +18,12 @@ function Html({ title, description, body, debug }) {
         <meta name="description" content={description || config.description} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="apple-touch-icon" href="apple-touch-icon.png" />
+        <link rel="stylesheet" href="main.css" />
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto" />
-        <script src={'/app.js?' + new Date().getTime()} />
       </head>
       <body>
         <div id="app" dangerouslySetInnerHTML={{ __html: body }} />
+        <script src={'/app.js?' + new Date().getTime()} async />
         <GoogleAnalytics />
       </body>
     </html>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "eslint": "^1.7.3",
     "eslint-config-airbnb": "0.1.0",
     "eslint-plugin-react": "^3.6.3",
+    "extract-text-webpack-plugin": "^0.9.1",
     "fbjs": "^0.4.0",
     "file-loader": "^0.8.4",
     "git-repository": "^0.1.1",
@@ -37,7 +38,7 @@
     "style-loader": "^0.13.0",
     "through2": "^2.0.0",
     "url-loader": "^0.5.6",
-    "webpack": "^1.12.2",
+    "webpack": "^1.12.6",
     "webpack-dev-middleware": "^1.2.0",
     "webpack-hot-middleware": "^2.4.1"
   },

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -8,6 +8,8 @@ import path from 'path';
 import webpack from 'webpack';
 import merge from 'lodash.merge';
 
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+
 const DEBUG = !process.argv.includes('release');
 const VERBOSE = process.argv.includes('verbose');
 const WATCH = global.watch;
@@ -106,6 +108,9 @@ const appConfig = merge({}, config, {
   plugins: [
     ...config.plugins,
     ...(DEBUG ? [] : [
+      new ExtractTextPlugin('main.css', {
+        allChunks: true
+      }),
       new webpack.optimize.DedupePlugin(),
       new webpack.optimize.UglifyJsPlugin({
         compress: {
@@ -143,9 +148,13 @@ const appConfig = merge({}, config, {
         },
       }) : JS_LOADER,
       ...config.module.loaders,
-      {
+      DEBUG ? {
         test: /\.scss$/,
-        loaders: ['style-loader', 'css-loader', 'postcss-loader'],
+        loaders:  ['style-loader', 'css-loader', 'postcss-loader']
+      } : {
+        // only create main.css file in production build since it breaks hot reloading during development
+        test: /\.scss$/,
+        loader: ExtractTextPlugin.extract('style-loader', 'css-loader!postcss-loader')
       },
     ],
   },


### PR DESCRIPTION
Better for SEO. Page can load with JS disabled.

Resolves https://github.com/koistya/react-static-boilerplate/issues/34

Also made JS async, therefore static page is first class citizen for maximum performance. The react app loads when it loads, doesn't hold up the perceived page performance.