### PR TITLE
Use isomorphic-style-loader to render <style> on server

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,7 +16,13 @@ const routes = {}; // Auto-generated on build. See tools/lib/routes-loader.js
 const route = async (path, callback) => {
   const handler = routes[path] || routes['/404'];
   const component = await handler();
-  await callback(<Layout>{React.createElement(component)}</Layout>);
+
+  const css = [];
+  const context = {
+    insertCss: styles => css.push(styles._getCss()),
+  };
+
+  await callback(<Layout context={context}>{React.createElement(component)}</Layout>, css);
 };
 
 function run() {

--- a/app.js
+++ b/app.js
@@ -21,6 +21,9 @@ const route = async (path, callback) => {
   const context = {
     insertCss: styles => css.push(styles._getCss()),
   };
+  if (canUseDOM) {
+    context.insertCss = (styles) => styles._insertCss();
+  }
 
   await callback(<Layout context={context}>{React.createElement(component)}</Layout>, css);
 };

--- a/components/Html/Html.js
+++ b/components/Html/Html.js
@@ -8,7 +8,7 @@ import React, { PropTypes } from 'react';
 import GoogleAnalytics from '../GoogleAnalytics';
 import config from '../../config';
 
-function Html({ title, description, body, debug }) {
+function Html({ title, description, body, css, debug }) {
   return (
     <html className="no-js" lang="">
       <head>
@@ -20,6 +20,7 @@ function Html({ title, description, body, debug }) {
         <link rel="apple-touch-icon" href="apple-touch-icon.png" />
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto" />
         <script src={'/app.js?' + new Date().getTime()} />
+        <style id="css" dangerouslySetInnerHTML={{ __html: css }} />
       </head>
       <body>
         <div id="app" dangerouslySetInnerHTML={{ __html: body }} />
@@ -33,6 +34,7 @@ Html.propTypes = {
   title: PropTypes.string,
   description: PropTypes.string,
   body: PropTypes.string.isRequired,
+  css: PropTypes.string,
   debug: PropTypes.bool.isRequired,
 };
 

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -4,21 +4,46 @@
  * Copyright (c) Konstantin Tarkus (@koistya) | MIT license
  */
 
-import React, { PropTypes } from 'react';
-import './Layout.scss';
+import React, { Component, PropTypes } from 'react';
+import emptyFunction from 'fbjs/lib/emptyFunction';
+import style from './Layout.scss';
 import Navigation from '../Navigation';
 
-function Layout({ children }) {
-  return (
-    <div className="Layout">
-      <Navigation />
-      {children}
-    </div>
-  );
-}
+class Layout extends Component {
+  static propTypes = {
+    context: PropTypes.shape({
+      insertCss: PropTypes.func,
+    }),
+    children: PropTypes.element.isRequired,
+  };
 
-Layout.propTypes = {
-  children: PropTypes.element.isRequired,
-};
+  static childContextTypes = {
+    insertCss: PropTypes.func.isRequired,
+  };
+
+  getChildContext() {
+    const context = this.props.context;
+    return {
+      insertCss: context.insertCss || emptyFunction,
+    };
+  }
+
+  componentWillMount() {
+    this.removeCss = this.props.context.insertCss(style);
+  }
+
+  componentWillUnmount() {
+    this.removeCss();
+  }
+
+  render() {
+    return (
+      <div className="Layout">
+        <Navigation />
+        {this.props.children}
+      </div>
+    );
+  }
+}
 
 export default Layout;

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -33,7 +33,7 @@ class Layout extends Component {
   }
 
   componentWillUnmount() {
-    this.removeCss();
+    setTimeout(this.removeCss, 0);
   }
 
   render() {

--- a/components/Link/Link.js
+++ b/components/Link/Link.js
@@ -5,9 +5,7 @@
  */
 
 import React, { Component, PropTypes } from 'react';
-import style from './Link.scss';
 import Location from '../../core/Location';
-import withStyles from '../withStyles.js';
 
 function isLeftClickEvent(event) {
   return event.button === 0;
@@ -59,4 +57,4 @@ class Link extends Component {
 
 }
 
-export default withStyles(Link, style);
+export default Link;

--- a/components/Link/Link.js
+++ b/components/Link/Link.js
@@ -5,8 +5,9 @@
  */
 
 import React, { Component, PropTypes } from 'react';
-import './Link.scss';
+import style from './Link.scss';
 import Location from '../../core/Location';
+import withStyles from '../withStyles.js';
 
 function isLeftClickEvent(event) {
   return event.button === 0;
@@ -58,4 +59,4 @@ class Link extends Component {
 
 }
 
-export default Link;
+export default withStyles(Link, style);

--- a/components/Link/Link.scss
+++ b/components/Link/Link.scss
@@ -1,9 +1,0 @@
-/**
- * React Static Boilerplate
- * https://github.com/koistya/react-static-boilerplate
- * Copyright (c) Konstantin Tarkus (@koistya) | MIT license
- */
-
-.Link {
-
-}

--- a/components/Navigation/Navigation.js
+++ b/components/Navigation/Navigation.js
@@ -5,8 +5,9 @@
  */
 
 import React from 'react';
-import './Navigation.scss';
+import style from './Navigation.scss';
 import Link from '../Link';
+import withStyles from '../withStyles.js';
 
 function Navigation() {
   return (
@@ -21,4 +22,4 @@ function Navigation() {
   );
 }
 
-export default Navigation;
+export default withStyles(Navigation, style);

--- a/components/withStyles.js
+++ b/components/withStyles.js
@@ -1,0 +1,23 @@
+import React, { Component, PropTypes } from 'react';
+
+function withStyles(BaseComponent, ...styles) {
+  return class StyledComponent extends Component {
+    static contextTypes = {
+      insertCss: PropTypes.func.isRequired,
+    };
+
+    componentWillMount() {
+      this.removeCss = this.context.insertCss.apply(undefined, styles);
+    }
+
+    componentWillUnmount() {
+      this.removeCss();
+    }
+
+    render() {
+      return <BaseComponent {...this.props} />;
+    }
+  };
+}
+
+export default withStyles;

--- a/components/withStyles.js
+++ b/components/withStyles.js
@@ -11,7 +11,7 @@ function withStyles(BaseComponent, ...styles) {
     }
 
     componentWillUnmount() {
-      this.removeCss();
+      setTimeout(this.removeCss, 0);
     }
 
     render() {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "git-repository": "^0.1.1",
     "glob": "^5.0.15",
     "history": "^1.12.6",
+    "isomorphic-style-loader": "0.0.5",
     "hygienist-middleware": "^0.1.0",
     "lodash.merge": "^3.3.2",
     "mkdirp": "^0.5.1",

--- a/tools/render.js
+++ b/tools/render.js
@@ -35,9 +35,10 @@ function getPages() {
   });
 }
 
-async function renderPage(page, component) {
+async function renderPage(page, component, css) {
   const data = {
     body: ReactDOM.renderToString(component),
+    css: css.join(' '),
   };
   const file = join(__dirname, '../build', page.file.substr(0, page.file.lastIndexOf('.')) + '.html');
   const html = '<!doctype html>\n' + ReactDOM.renderToStaticMarkup(<Html debug={DEBUG} {...data} />);

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -177,7 +177,7 @@ const pagesConfig = merge({}, config, {
       ...config.module.loaders,
       {
         test: /\.scss$/,
-        loaders: ['css-loader', 'postcss-loader'],
+        loaders: ['isomorphic-style-loader', 'css-loader', 'postcss-loader'],
       },
     ],
   },

--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -79,6 +79,10 @@ const config = {
         test: /\.(eot|ttf|wav|mp3)$/,
         loader: 'file-loader',
       },
+      {
+        test: /\.scss$/,
+        loaders: ['isomorphic-style-loader', 'css-loader', 'postcss-loader'],
+      },
     ],
   },
   postcss: function plugins(bundler) {
@@ -143,10 +147,6 @@ const appConfig = merge({}, config, {
         },
       }) : JS_LOADER,
       ...config.module.loaders,
-      {
-        test: /\.scss$/,
-        loaders: ['style-loader', 'css-loader', 'postcss-loader'],
-      },
     ],
   },
 });
@@ -175,10 +175,6 @@ const pagesConfig = merge({}, config, {
     loaders: [
       JS_LOADER,
       ...config.module.loaders,
-      {
-        test: /\.scss$/,
-        loaders: ['isomorphic-style-loader', 'css-loader', 'postcss-loader'],
-      },
     ],
   },
 });


### PR DESCRIPTION
Use https://github.com/kriasoft/isomorphic-style-loader to render critical styles on the server, without needing an extra http request nor loading styles for unused components.

This closes https://github.com/koistya/react-static-boilerplate/issues/28 and builds off the work from https://github.com/kriasoft/isomorphic-style-loader/issues/5. This would also supersede PR https://github.com/koistya/react-static-boilerplate/pull/41 and close https://github.com/koistya/react-static-boilerplate/issues/34.