### PR TITLE
Auto generate blog post routes and pages

### DIFF
--- a/components/Layout/Navigation.js
+++ b/components/Layout/Navigation.js
@@ -26,6 +26,8 @@ class Navigation extends React.Component {
       <nav className="mdl-navigation" ref="root">
         <Link className="mdl-navigation__link" to="/">Home</Link>
         <Link className="mdl-navigation__link" to="/about">About</Link>
+        <Link className="mdl-navigation__link" to="/blog/2016/07/01/Post-1">Post 1</Link>
+        <Link className="mdl-navigation__link" to="/blog/2016/07/01/Post-2">Post 2</Link>
         <Link className="mdl-navigation__link" to="/not-found">Not Found</Link>
       </nav>
     );

--- a/core/router.js
+++ b/core/router.js
@@ -57,7 +57,12 @@ function resolve(routes, context) {
     }
 
     // TODO: Fetch data required data for the route. See "routes.json" file in the root directory.
-    return route.load().then(Page => <Page.default route={route} error={context.error} />);
+    return route.load().then(results => {
+      let Page = results.shift();
+      let data = results;
+      
+      return <Page.default route={route} data={data} error={context.error} />
+    });
   }
 
   const error = new Error('Page not found');

--- a/docs/routing-and-navigation.md
+++ b/docs/routing-and-navigation.md
@@ -55,9 +55,9 @@ The [`routes-loader`](../utils/routes-loader.js) performs three tasks:
 * Converts JSON-based routes into JavaScript
 * Converts parametrized URL path strings into regular expressions by using
   [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp)
-* Wraps page/screen UI components' path strings into either `require.ensure(..)` (Webpack 1.x) or
-  `System.import(..)` (Webpack 2.x). For more information see
-  [code-splitting](https://webpack.github.io/docs/code-splitting) in Webpack docs.
+* Wraps page/screen UI components' path strings into `() => System.import(..)` (Webpack 2.x). For
+  more information see [code-splitting](https://webpack.github.io/docs/code-splitting) in Webpack
+  docs.
 
 For example, a route like this:
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es2015-webpack": "^6.4.1",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.5.0",
     "babel-register": "^6.9.0",
@@ -67,7 +68,7 @@
     "stylelint": "^6.8.0",
     "stylelint-config-standard": "^10.0.0",
     "url-loader": "^0.5.7",
-    "webpack": "^1.13.1",
+    "webpack": "^2.1.0-beta.15",
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.12.0"
   },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "file-loader": "^0.9.0",
     "firebase-tools": "^3.0.4",
     "front-matter": "^2.1.0",
+    "glob": "^7.0.5",
     "highlight.js": "^9.5.0",
     "json-loader": "^0.5.4",
     "markdown-it": "^7.0.0",

--- a/pages/post/index.js
+++ b/pages/post/index.js
@@ -1,0 +1,31 @@
+/**
+ * React Static Boilerplate
+ * https://github.com/kriasoft/react-static-boilerplate
+ *
+ * Copyright © 2015-present Kriasoft, LLC. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE.txt file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import Layout from '../../components/Layout';
+
+class PostPage extends React.Component {
+
+  componentDidMount() {
+    console.log(this.props)
+  }
+
+  render() {
+    return (
+      <Layout>
+        <h1>{this.props.data[0].title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: this.props.data[0].html }} />
+      </Layout>
+    );
+  }
+
+}
+
+export default PostPage;

--- a/posts/2016-07-01-Post-1.md
+++ b/posts/2016-07-01-Post-1.md
@@ -1,0 +1,69 @@
+---
+title: Post 1
+page: post
+---
+
+## Cadme comitum fecere
+
+Lorem markdownum velis auras figuram spes solebat spectabat, cum alium,
+plenissima aratri visae herbarum in corpore silvas consumpta. Subito virgae nec
+paratae flexit et niveae repperit erat paratu cum albis steterat conclamat hic!
+
+Nocte suae ligat! *Si* nitidum pervia, illa tua, ab minimo pasci dabitur? In
+fictus concurreret pennis, illis cum accipe rogavi in et nostro cum lacertis
+hostibus ab saxo ne. Genibusque vixque; sine videt terribili lucos ipsum vobis
+resque, et suum pietatis fulvis, est velle. Semele oscula ferat frigidus mactata
+montes, es me parari, piae.
+
+## Inflataque ait leves frigida
+
+Letum per ipsa nostro animae, mari illuc in levi corpus aestibus excussam
+deflentem sic cuius. Venere dedit illa cui in quo senecta artus bella inficit,
+Achaica. Videbatur crinem resonantia alto dea umida dicitur igne; meus signa
+habet; est. Cognovit coepta: similes fugis: habuissem votivi liquida: ictus visi
+nostra me Adoni.
+
+## Laedar cum margine quoque
+
+Quam dato ullis, acer venturi volantes! Tuam non non cursu acta hic, novem
+nutrit, in sidera viscera iam fontes tempora, omnes. Saturnius artus inquit,
+conatoque erectos lenius, carinae, ora est infamia elige per Medusaei induitur.
+Quem quem ab postquam tunc frondescere nodis capiam labique. Voluere luce
+Semeles.
+
+```
+    if (delete(digital, hibernateSoft, dynamicExcelVpn) > io_secondary_led /
+            84) {
+        disk = load;
+        orientationPci.matrix_laptop(modelSsdTweet);
+    } else {
+        kdeEmoticonLed.mebibyte_algorithm_domain(2,
+                hackerCtr.rom_iso_desktop.scarewarePrimaryBankruptcy(station,
+                disk_mask_matrix, restore_crt));
+        cameraSpyware(4, multitasking(-3, log_dfs_controller));
+        menuCisc.swappable -= w(mount_vle_unicode, 5);
+    }
+    var optic_spider = newbieFunctionThick(-3, esportsKbpsUnix);
+    var dvd_ctp_resolution = dithering;
+```
+
+## Usus fixurus illi petunt
+
+Domosque tune amas mihi adhuc et *alter per* suasque versavitque iners
+crescentemque nomen verba nunc. Acervos hinc natus si habet. Et cervix imago
+quod! Arduus dolet!
+
+```
+    cpcDdrCommand.window(moodleAlpha, im, server_alpha.doubleVrmlMonochrome(
+            iosBar - -2, white_dual, ad(2, 94, 83)));
+    mbps_typeface_publishing.bit.host_flash_capacity(click(90,
+            cyberspace_srgb_pup - mpeg, marketing_trackback +
+            table_plagiarism_domain));
+    syn_e = powerExtension * defragmentNntpOsd(alertOutputNode(pop,
+            pageResponsiveDrive));
+    method -= switch_newsgroup_flaming;
+```
+
+Aliquid mansura arida altismunera **in illi**. Dignus vir pontum *crimen
+versabat* carpunt omnes rotis Canentem erant in Oebalio, et manu senecta
+iungere. Prima diurnis!

--- a/posts/2016-07-01-Post-2.md
+++ b/posts/2016-07-01-Post-2.md
@@ -1,0 +1,69 @@
+---
+title: Post 2
+page: post
+---
+
+## Cadme comitum fecere
+
+Lorem markdownum velis auras figuram spes solebat spectabat, cum alium,
+plenissima aratri visae herbarum in corpore silvas consumpta. Subito virgae nec
+paratae flexit et niveae repperit erat paratu cum albis steterat conclamat hic!
+
+Nocte suae ligat! *Si* nitidum pervia, illa tua, ab minimo pasci dabitur? In
+fictus concurreret pennis, illis cum accipe rogavi in et nostro cum lacertis
+hostibus ab saxo ne. Genibusque vixque; sine videt terribili lucos ipsum vobis
+resque, et suum pietatis fulvis, est velle. Semele oscula ferat frigidus mactata
+montes, es me parari, piae.
+
+## Inflataque ait leves frigida
+
+Letum per ipsa nostro animae, mari illuc in levi corpus aestibus excussam
+deflentem sic cuius. Venere dedit illa cui in quo senecta artus bella inficit,
+Achaica. Videbatur crinem resonantia alto dea umida dicitur igne; meus signa
+habet; est. Cognovit coepta: similes fugis: habuissem votivi liquida: ictus visi
+nostra me Adoni.
+
+## Laedar cum margine quoque
+
+Quam dato ullis, acer venturi volantes! Tuam non non cursu acta hic, novem
+nutrit, in sidera viscera iam fontes tempora, omnes. Saturnius artus inquit,
+conatoque erectos lenius, carinae, ora est infamia elige per Medusaei induitur.
+Quem quem ab postquam tunc frondescere nodis capiam labique. Voluere luce
+Semeles.
+
+```
+    if (delete(digital, hibernateSoft, dynamicExcelVpn) > io_secondary_led /
+            84) {
+        disk = load;
+        orientationPci.matrix_laptop(modelSsdTweet);
+    } else {
+        kdeEmoticonLed.mebibyte_algorithm_domain(2,
+                hackerCtr.rom_iso_desktop.scarewarePrimaryBankruptcy(station,
+                disk_mask_matrix, restore_crt));
+        cameraSpyware(4, multitasking(-3, log_dfs_controller));
+        menuCisc.swappable -= w(mount_vle_unicode, 5);
+    }
+    var optic_spider = newbieFunctionThick(-3, esportsKbpsUnix);
+    var dvd_ctp_resolution = dithering;
+```
+
+## Usus fixurus illi petunt
+
+Domosque tune amas mihi adhuc et *alter per* suasque versavitque iners
+crescentemque nomen verba nunc. Acervos hinc natus si habet. Et cervix imago
+quod! Arduus dolet!
+
+```
+    cpcDdrCommand.window(moodleAlpha, im, server_alpha.doubleVrmlMonochrome(
+            iosBar - -2, white_dual, ad(2, 94, 83)));
+    mbps_typeface_publishing.bit.host_flash_capacity(click(90,
+            cyberspace_srgb_pup - mpeg, marketing_trackback +
+            table_plagiarism_domain));
+    syn_e = powerExtension * defragmentNntpOsd(alertOutputNode(pop,
+            pageResponsiveDrive));
+    method -= switch_newsgroup_flaming;
+```
+
+Aliquid mansura arida altismunera **in illi**. Dignus vir pontum *crimen
+versabat* carpunt omnes rotis Canentem erant in Oebalio, et manu senecta
+iungere. Prima diurnis!

--- a/utils/routes-loader.js
+++ b/utils/routes-loader.js
@@ -29,7 +29,7 @@ function escape(text) {
  *     pattern: /^\\/about(?:\/(?=$))?$/i,
  *     keys: [],
  *     page: './pages/about',
- *     load: function () { return new Promise(resolve => require(['./pages/about'], resolve)); }
+ *     load: function () { return System.load('./pages/about'); }
  *   }
  */
 module.exports = function routesLoader(source) {
@@ -42,22 +42,14 @@ module.exports = function routesLoader(source) {
     const keys = [];
     const pattern = toRegExp(route.path, keys);
     const require = route.path === '/' || route.path === '/error' ?
-      module => `Promise.resolve(require('${module}'))` :
-      module => `new Promise(function (resolve, reject) {
-        try {
-          require.ensure(['${module}'], function (require) {
-            resolve(require('${module}'));
-          });
-        } catch (err) {
-          reject(err);
-        }
-      })`;
+      module => `Promise.resolve(require('${escape(module)}'))` :
+      module => `System.import('${escape(module)}')`;
     output.push('  {\n');
     output.push(`    path: '${escape(route.path)}',\n`);
     output.push(`    pattern: ${pattern.toString()},\n`);
     output.push(`    keys: ${JSON.stringify(keys)},\n`);
     output.push(`    page: '${escape(route.page)}',\n`);
-    output.push(`    load: function load() { return ${require(escape(route.page))}; },\n`);
+    output.push(`    load: function load() { return ${require(route.page)}; },\n`);
     output.push('  },\n');
   }
 

--- a/utils/routes-loader.js
+++ b/utils/routes-loader.js
@@ -9,6 +9,10 @@
  */
 
 const toRegExp = require('path-to-regexp');
+const glob = require('glob');
+const fs = require('fs');
+const path = require('path');
+const frontmatter = require('front-matter');
 
 function escape(text) {
   return text.replace('\'', '\\\'').replace('\\', '\\\\');
@@ -36,20 +40,42 @@ module.exports = function routesLoader(source) {
   this.cacheable();
 
   const output = ['[\n'];
+  const posts = glob.sync('./posts/*.md');
   const routes = JSON.parse(source);
+  
+  posts.forEach(post => {
+    const file = fs.readFileSync(post, 'utf8');
+    const date = path.basename(post, '.md').split('-');
+    const fm = frontmatter(file);
+
+    routes.push({
+      path: path.join('/blog', date.shift(), date.shift(), date.shift(), date.join('-')),
+      page: './pages/' + fm.attributes.page,
+      data: [ post ]
+    });
+  });
 
   for (const route of routes) {
     const keys = [];
     const pattern = toRegExp(route.path, keys);
-    const require = route.path === '/' || route.path === '/error' ?
-      module => `Promise.resolve(require('${escape(module)}'))` :
-      module => `System.import('${escape(module)}')`;
+    const requirePage = route.path === '/' || route.path === '/error' ?
+      `Promise.resolve(require('${route.page}'))` :
+      `System.import('${route.page}')`;
+
+    var requireData = [];
+    if (route.data && route.data.length) {
+      requireData = route.data.map(resource => {
+        return `System.import('${resource}')`;
+      });
+    }
+
+    const require = `[ ${requirePage}, ${requireData.join(', ')} ]`;
     output.push('  {\n');
     output.push(`    path: '${escape(route.path)}',\n`);
     output.push(`    pattern: ${pattern.toString()},\n`);
     output.push(`    keys: ${JSON.stringify(keys)},\n`);
     output.push(`    page: '${escape(route.page)}',\n`);
-    output.push(`    load: function load() { return ${require(route.page)}; },\n`);
+    output.push(`    load: function load() { return Promise.all(${require}); },\n`);
     output.push('  },\n');
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -183,6 +183,10 @@ const config = {
 
 };
 
+// Integrate Webpack 2.x (replace 'es2015' preset with 'es2015-webpack')
+const babelConfig = config.module.loaders.find(x => x.loader === 'babel-loader').query;
+babelConfig.presets = babelConfig.presets.map(x => (x === 'es2015' ? `${x}-webpack` : x));
+
 // Optimize the bundle in release (production) mode
 if (!isDebug) {
   config.plugins.push(new webpack.optimize.DedupePlugin());
@@ -192,9 +196,8 @@ if (!isDebug) {
 
 // Hot Module Replacement (HMR) + React Hot Reload
 if (isDebug && useHMR) {
+  babelConfig.plugins.unshift('react-hot-loader/babel');
   config.entry.unshift('react-hot-loader/patch', 'webpack-hot-middleware/client');
-  config.module.loaders.find(x => x.loader === 'babel-loader')
-    .query.plugins.unshift('react-hot-loader/babel');
   config.plugins.push(new webpack.HotModuleReplacementPlugin());
   config.plugins.push(new webpack.NoErrorsPlugin());
 }


### PR DESCRIPTION
Initial proof of concept for https://github.com/kriasoft/react-static-boilerplate/issues/103

- Creates a route for each `.md` file found in `/posts` based on the name of post. This needs to be made more robust to allow more routing options. Maybe setting the route as a front matter property?
- Determines which page to insert markdown data via front matter `page` property
- Markdown document is set as a `data` item in `routes.json`. Data items are requested via `System.import()` inside the `route.load()` method. A `Promise.all()` is used to make sure the page and data promises are all fulfilled before proceeding to rendering.

Still lots to improve here but it works! Thoughts on general approach?
