### PR TITLE
Add type and prefix directory when importing main.js

### DIFF
--- a/public/index.ejs
+++ b/public/index.ejs
@@ -15,7 +15,7 @@
   <body>
     <div id="container"></div>
     <script src="https://cdn.rawgit.com/tleunen/react-mdl/master/extra/material.min.js"></script>
-    <script src="<%= bundle %>"></script>
+    <script type="text/javascript" src=".<%= bundle %>"></script>
     <%_ if (!debug && config.trackingID) { _%>
     <script>
       window.ga=function(){ga.q.push(arguments)};ga.q=[];ga.l=+new Date;


### PR DESCRIPTION
RSB will not work in a hybrid mobile app environment (i.e. cordova) unless <script> contains a type and ./ prefix.
