### PR TITLE
Fixes a typo in the sass recipe

### DIFF
--- a/docs/recipes/how-to-use-sass.md
+++ b/docs/recipes/how-to-use-sass.md
@@ -52,7 +52,7 @@ const config = {
   ...
   postcss(bundler) {
     return {
-      default: [
+      defaults: [
         ...
       ],
       sass: [


### PR DESCRIPTION
Fixes issue #124 by changing 'default' to 'defaults' in postcss config