### PR TITLE
docs: fixed path is not defined error

### DIFF
--- a/docs/recipes/deploy-to-github-pages.md
+++ b/docs/recipes/deploy-to-github-pages.md
@@ -5,6 +5,10 @@
 Add deployment script to `run.js`:
 
 ```js
+const path = require('path');
+```
+
+```js
 tasks.set('publish', () => {
   const remote = {
     url: 'https://github.com/<owner>/<repo>.git', // TODO: Update deployment URL


### PR DESCRIPTION
Error:

```bash 
ReferenceError: path is not defined
    at tasks.set (/Users/eneff/Desktop/react static/run.js:105:23)
    at Promise.resolve.then (/Users/eneff/Desktop/react static/run.js:31:54)
    at process._tickCallback (internal/process/next_tick.js:103:7)
    at Module.runMain (module.js:607:11)
    at run (bootstrap_node.js:420:7)
    at startup (bootstrap_node.js:139:9)
    at bootstrap_node.js:535:3
```