### PR TITLE
fix background image in dev mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,7 @@ const config = {
   // Options affecting the output of the compilation
   output: {
     path: path.resolve(__dirname, './public/dist'),
-    publicPath: '/dist/',
+    publicPath: isDebug? `http://localhost:${process.env.PORT || 3000}/dist/` : '/dist/',
     filename: isDebug ? '[name].js?[hash]' : '[name].[hash].js',
     chunkFilename: isDebug ? '[id].js?[chunkhash]' : '[id].[chunkhash].js',
     sourcePrefix: '  ',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,7 @@ const config = {
   // Options affecting the output of the compilation
   output: {
     path: path.resolve(__dirname, './public/dist'),
-    publicPath: isDebug? `http://localhost:${process.env.PORT || 3000}/dist/` : '/dist/',
+    publicPath: isDebug ? `http://localhost:${process.env.PORT || 3000}/dist/` : '/dist/',
     filename: isDebug ? '[name].js?[hash]' : '[name].[hash].js',
     chunkFilename: isDebug ? '[id].js?[chunkhash]' : '[id].[chunkhash].js',
     sourcePrefix: '  ',


### PR DESCRIPTION
i run server in dev mode and use div elements with background-image: url(../public/some-path/image.jpg)
then it compiles to  background-image: url(/dist/hash.jpg) and is not shown by chrome browser.
`http://localhost:${process.env.PORT || 3000}/dist/` fixes that problem