### PR TITLE
Update README: yarn publish -> yarn run publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ project name as found in your [Firebase console](https://console.firebase.google
 this may have an additional identifier suffix than the shorter name you've provided. Then run: 
 
 ```shell
-$ yarn publish                  # Builds and deployes the app to Firebase
+$ yarn run publish                  # Builds and deployes the app to Firebase
 ```
 
 The first time you publish, you will be prompted to authenticate with Google and generate an


### PR DESCRIPTION
I'm pretty sure this is a simple typo in the readme. Here's what I see locally when I try to run `yarn publish`:

```
~/tmp/MyApp @kaladin> yarn publish
yarn publish v0.21.3
error Package marked as private, not publishing.
info Visit https://yarnpkg.com/en/docs/cli/publish for documentation about this command.
~/tmp/MyApp @kaladin> yarn run publish
yarn run v0.21.3
$ node tools/publish.js 
Starting 'deploy'...
Starting 'build'...
```