### PR TITLE
Moved footer outside of main area in layout

### DIFF
--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -35,8 +35,8 @@ class Layout extends React.Component {
           <Header />
           <main className="mdl-layout__content">
             <div {...this.props} className={cx(s.content, this.props.className)} />
-            <Footer />
           </main>
+          <Footer />
         </div>
       </div>
     );


### PR DESCRIPTION
Fixed the default layout so that the footer is at the bottom of the page.

Before:
![react-static-boilerplate-before](https://user-images.githubusercontent.com/14334617/28244438-be7493a2-69a8-11e7-958a-1f97e360845c.PNG)

After:
![react-static-boilerplate-after](https://user-images.githubusercontent.com/14334617/28244441-c46ad834-69a8-11e7-8695-8abb67e701cd.PNG)
