### PR TITLE
Replace Oups with Oops in ErrorPage

### DIFF
--- a/src/ErrorPage/ErrorPage.js
+++ b/src/ErrorPage/ErrorPage.js
@@ -99,7 +99,7 @@ class ErrorPage extends React.Component<any, Props, any> {
     const [code, title] =
       this.props.error && this.props.error.status === 404
         ? ['404', 'Page not found']
-        : ['Error', 'Oups, something went wrong'];
+        : ['Error', 'Oops, something went wrong'];
 
     return (
       <Container>


### PR DESCRIPTION
The ErrorPage, when not a 404, displays "**Oups**, something went wrong".

Oups is the [French spelling](https://en.wiktionary.org/wiki/oups) of the common [English interjection](https://en.wiktionary.org/wiki/oops), "Oops!" To native English speakers, this looks like a typo.

This pull request is a one word change, replacing Oups with the English spelling, Oops. The complete ErrorPage sentence is now, "**Oops**, something went wrong".